### PR TITLE
Don't use wildcard when installing manpage

### DIFF
--- a/StandAlone/StandAlone.pro
+++ b/StandAlone/StandAlone.pro
@@ -144,7 +144,7 @@ unix:!macx {
         appIcon256x256 \
         appIconScalable
 
-    manpage.files = share/man/man1/*.1.gz
+    manpage.files = share/man/man1/webcamoid.1.gz
     manpage.path = $${MANDIR}/man1
     manpage.CONFIG += no_check_exist
 


### PR DESCRIPTION
Qt 5.9 is confused by it