### PR TITLE
Unbreak with libav < 12

### DIFF
--- a/libAvKys/Plugins/VideoCapture/src/ffmpeg/src/convertvideoffmpeg.cpp
+++ b/libAvKys/Plugins/VideoCapture/src/ffmpeg/src/convertvideoffmpeg.cpp
@@ -35,6 +35,9 @@ extern "C"
     #include <libavutil/imgutils.h>
     #include <libavutil/pixdesc.h>
     #include <libavutil/mem.h>
+    #ifndef AV_CODEC_CAP_TRUNCATED
+    #define AV_CODEC_CAP_TRUNCATED CODEC_CAP_TRUNCATED
+    #endif
     #ifndef AV_CODEC_FLAG_TRUNCATED
     #define AV_CODEC_FLAG_TRUNCATED CODEC_FLAG_TRUNCATED
     #endif


### PR DESCRIPTION
`AV_CODEC_CAP_TRUNCATED` was introduced in FFmpeg 2.8 / libav 12 but Ubuntu 14.04.3 has libav 9.20.
Fixes #119 regression.

```
src/convertvideoffmpeg.cpp: In member function 'virtual bool ConvertVideoFFmpeg::init(const AkCaps&)':
src/convertvideoffmpeg.cpp:296:31: error: 'AV_CODEC_CAP_TRUNCATED' was not declared in this scope
     if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
                               ^
```
https://travis-ci.org/webcamoid/webcamoid/jobs/373338282
https://travis-ci.org/webcamoid/webcamoid/jobs/373338283
