### PR TITLE
Fix older USB based v4l2 device detection which doesn't promote FPS

### DIFF
--- a/libAvKys/Plugins/VideoCapture/src/v4l2sys/src/capturev4l2.cpp
+++ b/libAvKys/Plugins/VideoCapture/src/v4l2sys/src/capturev4l2.cpp
@@ -514,6 +514,7 @@ QVariantList CaptureV4L2Private::capsFps(int fd,
 
 #ifdef VIDIOC_ENUM_FRAMEINTERVALS
     v4l2_frmivalenum frmival {};
+    bool frameintervals = false;
     frmival.pixel_format = format.pixelformat;
     frmival.width = width;
     frmival.height = height;
@@ -544,6 +545,7 @@ QVariantList CaptureV4L2Private::capsFps(int fd,
 
         videoCaps.setProperty("fps", fps.toString());
         caps << QVariant::fromValue(videoCaps);
+        frameintervals = true;
     }
 #else
     struct v4l2_streamparm params;
@@ -562,6 +564,19 @@ QVariantList CaptureV4L2Private::capsFps(int fd,
         caps << QVariant::fromValue(videoCaps);
     }
 #endif
+
+    // Some older V4L2 devices does not provide FPS
+    // Information but they still work correctly
+    // FPS is unkown or various it depends with camera
+    if(frameintervals == false) {
+        AkCaps videoCaps;
+        videoCaps.setMimeType("video/unknown");
+        videoCaps.setProperty("fourcc", fourcc);
+        videoCaps.setProperty("width", width);
+        videoCaps.setProperty("height", height);
+        videoCaps.setProperty("fps", "0");
+        caps << QVariant::fromValue(videoCaps);
+    }
 
     return caps;
 }


### PR DESCRIPTION
## Type of change

Bugfix

## Summary

Some older Webcam v4l2 devices doesn not have constant FPS they stream as they can. I have old Logitech QuickCam Communicate STX which didn't work with Webcamoind but this PR makes it work.

## Target Environment

Linux v4l2