### PR TITLE
Blur everything except detected faces

### DIFF
--- a/libAvKys/Plugins/FaceDetect/share/qml/main.qml
+++ b/libAvKys/Plugins/FaceDetect/share/qml/main.qml
@@ -257,6 +257,10 @@ GridLayout {
                 text: qsTr("Blur")
                 markerType: "blur"
             }
+            ListElement {
+                text: qsTr("Blur Outer")
+                markerType: "blurouter"
+            }
         }
 
         onCurrentIndexChanged: FaceDetect.markerType = cbxMarkerType.model.get(currentIndex).markerType

--- a/libAvKys/Plugins/FaceDetect/src/facedetectelement.h
+++ b/libAvKys/Plugins/FaceDetect/src/facedetectelement.h
@@ -82,7 +82,8 @@ class FaceDetectElement: public AkElement
             MarkerTypeEllipse,
             MarkerTypeImage,
             MarkerTypePixelate,
-            MarkerTypeBlur
+            MarkerTypeBlur,
+            MarkerTypeBlurOuter
         };
 
         FaceDetectElement();


### PR DESCRIPTION
For a "virtual background" like feature (see issue #250), this pull request simply modifies the existing face detector to allow blurring not the faces, but everything except the faces.