### PR TITLE
Make first letter of Windows links uppercase

### DIFF
--- a/ports/deploy/installscript.windows.qs
+++ b/ports/deploy/installscript.windows.qs
@@ -17,5 +17,5 @@ Component.prototype.createOperations = function()
     for (var dir in installDir)
         component.addOperation("CreateShortcut",
                                 "@TargetDir@/bin/webcamoid.exe",
-                                installDir[dir] + "/webcamoid.lnk");
+                                installDir[dir] + "/Webcamoid.lnk");
 }


### PR DESCRIPTION
## Summary

This pull request renames the desktop icon, start menu entry and the link in the installation directory from `webcamoid` to `Webcamoid` because the application is written with an uppercase starting letter on its website and Windows users will expect this spelling to appear on their desktop.

I'm not sure why you create a link in the installation directory but even if this link is used from scripts this is not a breaking change because Windows filenames are not case-sensitive.

## Target Environment

* Operating System information: **Windows** (any version, any architecture)
