### PR TITLE
ApplicationWindow: allow positioning on any screen

### DIFF
--- a/StandAlone/share/qml/main.qml
+++ b/StandAlone/share/qml/main.qml
@@ -34,8 +34,6 @@ ApplicationWindow {
            + " - "
            + videoLayer.description(videoLayer.videoInput)
     visible: true
-    x: (Screen.width - mediaTools.windowWidth) / 2
-    y: (Screen.height - mediaTools.windowHeight) / 2
     width: mediaTools.windowWidth
     height: mediaTools.windowHeight
 
@@ -74,7 +72,11 @@ ApplicationWindow {
     onWidthChanged: mediaTools.windowWidth = width
     onHeightChanged: mediaTools.windowHeight = height
 
-    Component.onCompleted: chkFlash.updateVisibility()
+    Component.onCompleted: {
+        x = (Screen.width - mediaTools.windowWidth) / 2
+        y = (Screen.height - mediaTools.windowHeight) / 2
+        chkFlash.updateVisibility()
+    }
 
     Connections {
         target: mediaTools


### PR DESCRIPTION
Properties x and y were incorrectly bound such that any time the window
position changed it was reset. The intention was to only set the initial
window position when the application starts.

Move the code to the onCompleted() signal so it only fires once.

Closes issue #507.