### PR TITLE
VideoOutputAddEdit: fix pixel format size display

### DIFF
--- a/StandAlone/share/qml/VideoOutputAddEdit.qml
+++ b/StandAlone/share/qml/VideoOutputAddEdit.qml
@@ -164,8 +164,8 @@ Dialog {
                 let element = vcamFormats.itemAt(index)
                 let caps =
                     AkVideoCaps.create(element.format,
-                                       element.width,
-                                       element.height,
+                                       element.formatWidth,
+                                       element.formatHeight,
                                        AkFrac.create(element.fps,
                                                      1).toVariant())
                 addEdit.openOutputFormatDialog(index, caps)


### PR DESCRIPTION
When showing the pixel format dialog the format's pixel width and height were
incorrectly set from the GUI menu item's width and height. Correct to
use formatWidth and formatHeight.

Closes issue #528

