### PR TITLE
leftControls: size Column to not ellide Flash switch label

### DIFF
--- a/StandAlone/share/qml/main.qml
+++ b/StandAlone/share/qml/main.qml
@@ -140,7 +140,7 @@ ApplicationWindow {
     }
     ColumnLayout {
         id: leftControls
-        width: AkUnit.create(150 * AkTheme.controlScale, "dp").pixels
+        width: AkUnit.create(childrenRect.width * AkTheme.controlScale, "dp").pixels
         anchors.top: parent.top
         anchors.topMargin: AkUnit.create(16 * AkTheme.controlScale, "dp").pixels
         anchors.left: parent.left
@@ -160,7 +160,6 @@ ApplicationWindow {
             id: chkFlash
             text: qsTr("Use flash")
             checked: true
-            Layout.fillWidth: true
             visible: false
             Accessible.name: text
             Accessible.description: qsTr("Use flash when taking a photo")


### PR DESCRIPTION
When showing the pixel format dialog the format's pixel width and height were
incorrectly set from the GUI menu item's width and height. Correct to
use formatWidth and formatHeight.

Closes issue #528

