### PR TITLE
cmake: add uninstall build target to aid development cycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,3 +396,22 @@ if (UNIX AND NOT ANDROID AND NOT MACX)
     install(FILES webcamoid.desktop DESTINATION ${DATAROOTDIR}/applications)
     install(FILES io.github.webcamoid.Webcamoid.metainfo.xml DESTINATION ${DATAROOTDIR}/metainfo)
 endif ()
+
+# uninstall target
+# taken from https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+# usage: "cmake --build path/to/build/directory --target uninstall"
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+  # add your project-specific directory paths here and they'll be added to "install_manifest.txt" in the build directory
+  # and therefore removed when the uninstall target executes.
+  install(CODE "list(APPEND CMAKE_INSTALL_MANIFEST_FILES \"\${CMAKE_INSTALL_PREFIX}/lib/avkys\")")
+  install(CODE "list(APPEND CMAKE_INSTALL_MANIFEST_FILES \"\${CMAKE_INSTALL_PREFIX}/share/licenses/webcamoid\")")
+endif()
+

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -20,3 +20,7 @@ foreach(file ${files})
   endif()
 endforeach()
 
+# remove any empty directories if DESTDIR is set
+if(NOT "$ENV{DESTDIR}" STREQUAL "" AND EXISTS "$ENV{DESTDIR}")
+  exec_program("@CMAKE_COMMAND@" ARGS "-E rm -r \"$ENV{DESTDIR}\"")
+endif()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,22 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E rm -r \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
+


### PR DESCRIPTION
Use as: cmake --build your-build-path --target uninstall

Closes issue #530.
