### PR TITLE
Fix: ensure pkexec can always execute shell scripts

### DIFF
--- a/libAvKys/Plugins/VirtualCamera/src/akvcam/src/vcamak.cpp
+++ b/libAvKys/Plugins/VirtualCamera/src/akvcam/src/vcamak.cpp
@@ -1963,9 +1963,10 @@ bool VCamAkPrivate::sudo(const QString &script)
     }
 
     QProcess su;
-    su.start(sudoBin, QStringList {});
+    su.start(sudoBin, QStringList {"sh"});
 
     if (su.waitForStarted()) {
+       qDebug() << "executing shell script with 'sh'" << Qt::endl << script.toUtf8();
        su.write(script.toUtf8());
        su.closeWriteChannel();
     }

--- a/libAvKys/Plugins/VirtualCamera/src/v4l2lb/src/vcamv4l2lb.cpp
+++ b/libAvKys/Plugins/VirtualCamera/src/v4l2lb/src/vcamv4l2lb.cpp
@@ -1201,9 +1201,10 @@ bool VCamV4L2LoopBackPrivate::sudo(const QString &script)
     }
 
     QProcess su;
-    su.start(sudoBin, QStringList {});
+    su.start(sudoBin, QStringList {"sh"});
 
     if (su.waitForStarted()) {
+       qDebug() << "executing shell script with 'sh'" << Qt::endl << script.toUtf8();
        su.write(script.toUtf8());
        su.closeWriteChannel();
     }


### PR DESCRIPTION
Debian, Ubuntu and deriviatives use a forked version of the polkit
package (that contains "pkexec"). When no command line is passed it
causes pkexec to fail (with its `--help`).

This causes installation, removal, and configuration of Virtual Cameras
to fail.

The fork occured in 2013 when upstream polkit replaced the configuration
system with executable Javascript using the Mozilla SpiderMonkey engine.

Upstream later added functionality that will get the user's shell from
/etc/passwd if the pkexec command line is empty.

That allowed webcamoid to work with upstream polkit versions but caused it to fail with
Debian and derivatives.

Solve this by always passing "sh" on the pkexec command-line.

Closes issue #510.