### PR TITLE
Fix QtCreator unable to find AkControls module

### DIFF
--- a/StandAlone/src/CMakeLists.txt
+++ b/StandAlone/src/CMakeLists.txt
@@ -142,7 +142,6 @@ endif ()
 add_definitions(-DCOMMONS_TARGET="webcamoid"
                 -DCOMMONS_APPNAME="Webcamoid"
                 -DCOMMONS_VERSION="${VERSION}")
-set(QML_IMPORT_PATH ../../libAvKys/Lib/share/qml)
 
 if (APPLE)
     install(TARGETS StandAlone DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/libAvKys/Plugins/AdjustHSL/CMakeLists.txt
+++ b/libAvKys/Plugins/AdjustHSL/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(AdjustHSL
 target_compile_definitions(AdjustHSL PRIVATE AVKYS_PLUGIN_ADJUSTHSL)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(AdjustHSL avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS AdjustHSL RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Aging/CMakeLists.txt
+++ b/libAvKys/Plugins/Aging/CMakeLists.txt
@@ -60,7 +60,6 @@ target_include_directories(Aging
 target_compile_definitions(Aging PRIVATE AVKYS_PLUGIN_AGING)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Aging avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Aging RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/AspectRatio/CMakeLists.txt
+++ b/libAvKys/Plugins/AspectRatio/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(AspectRatio
 target_compile_definitions(AspectRatio PRIVATE AVKYS_PLUGIN_ASPECTRATIO)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(AspectRatio avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS AspectRatio RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/AudioGen/CMakeLists.txt
+++ b/libAvKys/Plugins/AudioGen/CMakeLists.txt
@@ -56,7 +56,6 @@ target_include_directories(AudioGen
 target_compile_definitions(AudioGen PRIVATE AVKYS_PLUGIN_AUDIOGEN)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(AudioGen avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS AudioGen RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Blur/CMakeLists.txt
+++ b/libAvKys/Plugins/Blur/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(Blur
 target_compile_definitions(Blur PRIVATE AVKYS_PLUGIN_BLUR)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Blur avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Blur RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Cartoon/CMakeLists.txt
+++ b/libAvKys/Plugins/Cartoon/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Cartoon
 target_compile_definitions(Cartoon PRIVATE AVKYS_PLUGIN_CARTOON)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Cartoon avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Cartoon RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ChangeHSL/CMakeLists.txt
+++ b/libAvKys/Plugins/ChangeHSL/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ChangeHSL
 target_compile_definitions(ChangeHSL PRIVATE AVKYS_PLUGIN_CHANGEHSL)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ChangeHSL avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ChangeHSL RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Charify/CMakeLists.txt
+++ b/libAvKys/Plugins/Charify/CMakeLists.txt
@@ -61,7 +61,6 @@ target_include_directories(Charify
 target_compile_definitions(Charify PRIVATE AVKYS_PLUGIN_CHARIFY)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Charify avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Charify RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Cinema/CMakeLists.txt
+++ b/libAvKys/Plugins/Cinema/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Cinema
 target_compile_definitions(Cinema PRIVATE AVKYS_PLUGIN_CINEMA)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Cinema avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Cinema RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ColorFilter/CMakeLists.txt
+++ b/libAvKys/Plugins/ColorFilter/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ColorFilter
 target_compile_definitions(ColorFilter PRIVATE AVKYS_PLUGIN_COLORFILTER)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ColorFilter avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ColorFilter RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ColorReplace/CMakeLists.txt
+++ b/libAvKys/Plugins/ColorReplace/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ColorReplace
 target_compile_definitions(ColorReplace PRIVATE AVKYS_PLUGIN_COLORREPLACE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ColorReplace avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ColorReplace RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ColorTap/CMakeLists.txt
+++ b/libAvKys/Plugins/ColorTap/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ColorTap
 target_compile_definitions(ColorTap PRIVATE AVKYS_PLUGIN_COLORTAP)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ColorTap avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ColorTap RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ColorTransform/CMakeLists.txt
+++ b/libAvKys/Plugins/ColorTransform/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ColorTransform
 target_compile_definitions(ColorTransform PRIVATE AVKYS_PLUGIN_COLORTRANSFORM)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ColorTransform avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ColorTransform RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Contrast/CMakeLists.txt
+++ b/libAvKys/Plugins/Contrast/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Contrast
 target_compile_definitions(Contrast PRIVATE AVKYS_PLUGIN_CONTRAST)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Contrast avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Contrast RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Convolve/CMakeLists.txt
+++ b/libAvKys/Plugins/Convolve/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Convolve
 target_compile_definitions(Convolve PRIVATE AVKYS_PLUGIN_CONVOLVE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Convolve avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Convolve RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/DelayGrab/CMakeLists.txt
+++ b/libAvKys/Plugins/DelayGrab/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(DelayGrab
 target_compile_definitions(DelayGrab PRIVATE AVKYS_PLUGIN_DELAYGRAB)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(DelayGrab avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS DelayGrab RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Denoise/CMakeLists.txt
+++ b/libAvKys/Plugins/Denoise/CMakeLists.txt
@@ -61,7 +61,6 @@ target_include_directories(Denoise
 target_compile_definitions(Denoise PRIVATE AVKYS_PLUGIN_DENOISE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Denoise avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Denoise RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/DesktopCapture/src/CMakeLists.txt
+++ b/libAvKys/Plugins/DesktopCapture/src/CMakeLists.txt
@@ -61,7 +61,6 @@ target_include_directories(DesktopCaptureSrc
 target_compile_definitions(DesktopCaptureSrc PRIVATE AVKYS_PLUGIN_DESKTOPCAPTURE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(DesktopCaptureSrc avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS DesktopCaptureSrc RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Dice/CMakeLists.txt
+++ b/libAvKys/Plugins/Dice/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Dice
 target_compile_definitions(Dice PRIVATE AVKYS_PLUGIN_DICE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Dice avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Dice RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Distort/CMakeLists.txt
+++ b/libAvKys/Plugins/Distort/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Distort
 target_compile_definitions(Distort PRIVATE AVKYS_PLUGIN_DISTORT)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Distort avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Distort RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Dizzy/CMakeLists.txt
+++ b/libAvKys/Plugins/Dizzy/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Dizzy
 target_compile_definitions(Dizzy PRIVATE AVKYS_PLUGIN_DIZZY)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Dizzy avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Dizzy RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Edge/CMakeLists.txt
+++ b/libAvKys/Plugins/Edge/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Edge
 target_compile_definitions(Edge PRIVATE AVKYS_PLUGIN_EDGE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Edge avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Edge RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Emboss/CMakeLists.txt
+++ b/libAvKys/Plugins/Emboss/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Emboss
 target_compile_definitions(Emboss PRIVATE AVKYS_PLUGIN_EMBOSS)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Emboss avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Emboss RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Equalize/CMakeLists.txt
+++ b/libAvKys/Plugins/Equalize/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Equalize
 target_compile_definitions(Equalize PRIVATE AVKYS_PLUGIN_EQUALIZE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Equalize avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Equalize RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/FaceDetect/CMakeLists.txt
+++ b/libAvKys/Plugins/FaceDetect/CMakeLists.txt
@@ -71,7 +71,6 @@ target_include_directories(FaceDetect
 target_compile_definitions(FaceDetect PRIVATE AVKYS_PLUGIN_FACEDETECT)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(FaceDetect avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS FaceDetect RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/FaceTrack/CMakeLists.txt
+++ b/libAvKys/Plugins/FaceTrack/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(FaceTrack
 target_compile_definitions(FaceTrack PRIVATE AVKYS_PLUGIN_FACETRACK)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(FaceTrack avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS FaceTrack RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/FalseColor/CMakeLists.txt
+++ b/libAvKys/Plugins/FalseColor/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(FalseColor
 target_compile_definitions(FalseColor PRIVATE AVKYS_PLUGIN_FALSECOLOR)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(FalseColor avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS FalseColor RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Fire/CMakeLists.txt
+++ b/libAvKys/Plugins/Fire/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Fire
 target_compile_definitions(Fire PRIVATE AVKYS_PLUGIN_FIRE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Fire avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Fire RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Flip/CMakeLists.txt
+++ b/libAvKys/Plugins/Flip/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Flip
 target_compile_definitions(Flip PRIVATE AVKYS_PLUGIN_FLIP)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Flip avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Flip RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/FrameOverlap/CMakeLists.txt
+++ b/libAvKys/Plugins/FrameOverlap/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(FrameOverlap
 target_compile_definitions(FrameOverlap PRIVATE AVKYS_PLUGIN_FRAMEOVERLAP)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(FrameOverlap avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS FrameOverlap RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Gamma/CMakeLists.txt
+++ b/libAvKys/Plugins/Gamma/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Gamma
 target_compile_definitions(Gamma PRIVATE AVKYS_PLUGIN_GAMMA)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Gamma avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Gamma RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/GrayScale/CMakeLists.txt
+++ b/libAvKys/Plugins/GrayScale/CMakeLists.txt
@@ -57,7 +57,6 @@ target_include_directories(GrayScale
 target_compile_definitions(GrayScale PRIVATE AVKYS_PLUGIN_GRAYSCALE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(GrayScale avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS GrayScale RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Halftone/CMakeLists.txt
+++ b/libAvKys/Plugins/Halftone/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Halftone
 target_compile_definitions(Halftone PRIVATE AVKYS_PLUGIN_HALFTONE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Halftone avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Halftone RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Hypnotic/CMakeLists.txt
+++ b/libAvKys/Plugins/Hypnotic/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Hypnotic
 target_compile_definitions(Hypnotic PRIVATE AVKYS_PLUGIN_HYPNOTIC)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Hypnotic avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Hypnotic RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ImageSrc/CMakeLists.txt
+++ b/libAvKys/Plugins/ImageSrc/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(ImageSrc
 target_compile_definitions(ImageSrc PRIVATE AVKYS_PLUGIN_IMAGESRC)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ImageSrc avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ImageSrc RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Implode/CMakeLists.txt
+++ b/libAvKys/Plugins/Implode/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Implode
 target_compile_definitions(Implode PRIVATE AVKYS_PLUGIN_IMPLODE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Implode avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Implode RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Invert/CMakeLists.txt
+++ b/libAvKys/Plugins/Invert/CMakeLists.txt
@@ -57,7 +57,6 @@ target_include_directories(Invert
 target_compile_definitions(Invert PRIVATE AVKYS_PLUGIN_INVERT)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Invert avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Invert RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Life/CMakeLists.txt
+++ b/libAvKys/Plugins/Life/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Life
 target_compile_definitions(Life PRIVATE AVKYS_PLUGIN_LIFE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Life avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Life RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Matrix/CMakeLists.txt
+++ b/libAvKys/Plugins/Matrix/CMakeLists.txt
@@ -62,7 +62,6 @@ target_include_directories(Matrix
 target_compile_definitions(Matrix PRIVATE AVKYS_PLUGIN_MATRIX)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Matrix avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Matrix RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/MatrixTransform/CMakeLists.txt
+++ b/libAvKys/Plugins/MatrixTransform/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(MatrixTransform
 target_compile_definitions(MatrixTransform PRIVATE AVKYS_PLUGIN_MATRIXTRANSFORM)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(MatrixTransform avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS MatrixTransform RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Multiplex/CMakeLists.txt
+++ b/libAvKys/Plugins/Multiplex/CMakeLists.txt
@@ -56,7 +56,6 @@ target_include_directories(Multiplex
 target_compile_definitions(Multiplex PRIVATE AVKYS_PLUGIN_MULTIPLEX)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Multiplex avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Multiplex RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Nervous/CMakeLists.txt
+++ b/libAvKys/Plugins/Nervous/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Nervous
 target_compile_definitions(Nervous PRIVATE AVKYS_PLUGIN_NERVOUS)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Nervous avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Nervous RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Normalize/CMakeLists.txt
+++ b/libAvKys/Plugins/Normalize/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Normalize
 target_compile_definitions(Normalize PRIVATE AVKYS_PLUGIN_NORMALIZE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Normalize avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Normalize RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/OilPaint/CMakeLists.txt
+++ b/libAvKys/Plugins/OilPaint/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(OilPaint
 target_compile_definitions(OilPaint PRIVATE AVKYS_PLUGIN_OILPAINT)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(OilPaint avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS OilPaint RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Otsu/CMakeLists.txt
+++ b/libAvKys/Plugins/Otsu/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Otsu
 target_compile_definitions(Otsu PRIVATE AVKYS_PLUGIN_OTSU)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Otsu avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Otsu RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Photocopy/CMakeLists.txt
+++ b/libAvKys/Plugins/Photocopy/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Photocopy
 target_compile_definitions(Photocopy PRIVATE AVKYS_PLUGIN_PHOTOCOPY)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Photocopy avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Photocopy RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Pixelate/CMakeLists.txt
+++ b/libAvKys/Plugins/Pixelate/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Pixelate
 target_compile_definitions(Pixelate PRIVATE AVKYS_PLUGIN_PIXELATE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Pixelate avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Pixelate RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/PrimariesColors/CMakeLists.txt
+++ b/libAvKys/Plugins/PrimariesColors/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(PrimariesColors
 target_compile_definitions(PrimariesColors PRIVATE AVKYS_PLUGIN_PRIMARIESCOLORS)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(PrimariesColors avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS PrimariesColors RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Quark/CMakeLists.txt
+++ b/libAvKys/Plugins/Quark/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Quark
 target_compile_definitions(Quark PRIVATE AVKYS_PLUGIN_QUARK)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Quark avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Quark RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Radioactive/CMakeLists.txt
+++ b/libAvKys/Plugins/Radioactive/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Radioactive
 target_compile_definitions(Radioactive PRIVATE AVKYS_PLUGIN_RADIOACTIVE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Radioactive avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Radioactive RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Ripple/CMakeLists.txt
+++ b/libAvKys/Plugins/Ripple/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Ripple
 target_compile_definitions(Ripple PRIVATE AVKYS_PLUGIN_RIPPLE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Ripple avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Ripple RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Scale/CMakeLists.txt
+++ b/libAvKys/Plugins/Scale/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Scale
 target_compile_definitions(Scale PRIVATE AVKYS_PLUGIN_SCALE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Scale avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Scale RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/ScanLines/CMakeLists.txt
+++ b/libAvKys/Plugins/ScanLines/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(ScanLines
 target_compile_definitions(ScanLines PRIVATE AVKYS_PLUGIN_SCANLINES)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(ScanLines avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS ScanLines RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Scroll/CMakeLists.txt
+++ b/libAvKys/Plugins/Scroll/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Scroll
 target_compile_definitions(Scroll PRIVATE AVKYS_PLUGIN_SCROLL)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Scroll avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Scroll RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Shagadelic/CMakeLists.txt
+++ b/libAvKys/Plugins/Shagadelic/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Shagadelic
 target_compile_definitions(Shagadelic PRIVATE AVKYS_PLUGIN_SHAGADELIC)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Shagadelic avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Shagadelic RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/SwapRB/CMakeLists.txt
+++ b/libAvKys/Plugins/SwapRB/CMakeLists.txt
@@ -57,7 +57,6 @@ target_include_directories(SwapRB
 target_compile_definitions(SwapRB PRIVATE AVKYS_PLUGIN_SWAPRB)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(SwapRB avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS SwapRB RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Swirl/CMakeLists.txt
+++ b/libAvKys/Plugins/Swirl/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Swirl
 target_compile_definitions(Swirl PRIVATE AVKYS_PLUGIN_SWIRL)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Swirl avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Swirl RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Temperature/CMakeLists.txt
+++ b/libAvKys/Plugins/Temperature/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Temperature
 target_compile_definitions(Temperature PRIVATE AVKYS_PLUGIN_TEMPERATURE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Temperature avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Temperature RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/VideoCapture/src/CMakeLists.txt
+++ b/libAvKys/Plugins/VideoCapture/src/CMakeLists.txt
@@ -71,7 +71,6 @@ if (WIN32)
     target_link_libraries(VideoCaptureSrc ole32)
 endif ()
 
-set(QML_IMPORT_PATH ../../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS VideoCaptureSrc RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Vignette/CMakeLists.txt
+++ b/libAvKys/Plugins/Vignette/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Vignette
 target_compile_definitions(Vignette PRIVATE AVKYS_PLUGIN_VIGNETTE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Vignette avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Vignette RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/VirtualCamera/src/CMakeLists.txt
+++ b/libAvKys/Plugins/VirtualCamera/src/CMakeLists.txt
@@ -62,7 +62,6 @@ target_include_directories(VirtualCameraSrc
 target_compile_definitions(VirtualCameraSrc PRIVATE AVKYS_PLUGIN_VIRTUALCAMERA)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(VirtualCameraSrc avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS VirtualCameraSrc RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Warhol/CMakeLists.txt
+++ b/libAvKys/Plugins/Warhol/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Warhol
 target_compile_definitions(Warhol PRIVATE AVKYS_PLUGIN_WARHOL)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Warhol avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Warhol RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Warp/CMakeLists.txt
+++ b/libAvKys/Plugins/Warp/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Warp
 target_compile_definitions(Warp PRIVATE AVKYS_PLUGIN_WARP)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Warp avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Warp RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/Plugins/Wave/CMakeLists.txt
+++ b/libAvKys/Plugins/Wave/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(Wave
 target_compile_definitions(Wave PRIVATE AVKYS_PLUGIN_WAVE)
 list(TRANSFORM QT_COMPONENTS PREPEND Qt${QT_VERSION_MAJOR}:: OUTPUT_VARIABLE QT_LIBS)
 target_link_libraries(Wave avkys ${QT_LIBS})
-set(QML_IMPORT_PATH ../../Lib/share/qml)
 
 if (WIN32)
     install(TARGETS Wave RUNTIME DESTINATION ${PLUGINSDIR})

--- a/libAvKys/cmake/ProjectCommons.cmake
+++ b/libAvKys/cmake/ProjectCommons.cmake
@@ -157,3 +157,4 @@ set(GST_PLUGINS_SCANNER_PATH "${GST_PLUGINS_SCANNER}" CACHE FILEPATH "GStreamer 
 # Sudoer tool search directory
 
 set(EXTRA_SUDOER_TOOL_DIR "" CACHE PATH "Additional sudoer tool search directory")
+set(QML_IMPORT_PATH "${CMAKE_SOURCE_DIR}/libAvKys/Lib/share/qml" CACHE STRING "additional libraries" FORCE)


### PR DESCRIPTION
Although the project builds and executes correctly QtCreator IDE fails
to find the AkControl module because QML_IMPORT_PATH is set using a
relative not absolute path. QtCreator has a known bug for this:

"Editor shows Qml Module not found when using the new QML_ELEMENT
registration"
https://bugreports.qt.io/browse/QTCREATORBUG-24987

Fix this by prefixing relative path with CMAKE_CURRENT_SOURCE_DIR