### PR TITLE
MultiSrc: expose sync property to GUI

### DIFF
--- a/libAvKys/Plugins/MultiSrc/share/qml/main.qml
+++ b/libAvKys/Plugins/MultiSrc/share/qml/main.qml
@@ -164,4 +164,12 @@ GridLayout {
 
         onCurrentIndexChanged: updateStreams()
     }
+
+    CheckBox {
+     id: cbSynchronise
+     text: qsTr("Synchronise")
+     Layout.fillWidth: true
+     checked: MultiSrc.sync
+     onToggled:MultiSrc.setSync(checked)
+    }
 }


### PR DESCRIPTION
This completes the work done in commit 8ce3f3442 (2020-04-11) that added
the ability to control whether multimedia sources synchronise themselves to the
presentation time stamp (PTS) or not.

The option defaults to true but for some sources such as RTSP (e.g: network
cameras) synchronising to PTS can cause large (> 2 second) latency.

Allow the operator to disable sync so that frames are processed as soon
as they arrive.

Closes: issue #85.