### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET in macOS CI

### DIFF
--- a/StandAlone/WebcamoidInfo.plist
+++ b/StandAlone/WebcamoidInfo.plist
@@ -21,7 +21,7 @@
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.11</string>
+        <string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
         <key>NSHumanReadableCopyright</key>
         <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
         <key>NSPrincipalClass</key>

--- a/ports/ci/mac/build.sh
+++ b/ports/ci/mac/build.sh
@@ -31,6 +31,7 @@ export PATH="/usr/local/opt/qt@5/bin:$PATH"
 export LDFLAGS="$LDFLAGS -L/usr/local/opt/qt@5/lib"
 export CPPFLAGS="$CPPFLAGS -I/usr/local/opt/qt@5/include"
 export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
+export MACOSX_DEPLOYMENT_TARGET="10.14"
 INSTALL_PREFIX=${PWD}/webcamoid-data
 
 mkdir build


### PR DESCRIPTION
This is a minor bugfix of the CI script, fixing issue #562.

Basically, on macOS the compiler and linker need to know what version of macOS to target (i.e. which OS version is the earliest to support). If none is given, CMake has to guess this parameter based on the host OS version, which is undesirable.

There is a way to directly specify this target version though:
https://cmake.org/cmake/help/v3.24/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
Either the `CMAKE_OSX_DEPLOYMENT_TARGET` CMake variable or the `MACOSX_DEPLOYMENT_TARGET` environment variable can be set to the desired target version. This PR does the latter.

To test that the binary has the correct deployment target, macOSs `vtool` utility can be used like this:
```
$ vtool -show webcamoid-build/build/Webcamoid.app/Contents/MacOS/Webcamoid
webcamoid-build/build/Webcamoid.app/Contents/MacOS/Webcamoid:
Load command 9
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 10.14
      sdk 11.1
   ntools 1
     tool LD
  version 609.8
Load command 10
      cmd LC_SOURCE_VERSION
  cmdsize 16
  version 0.0
```
The above is what it looks like on my local machine (running macOS 10.15.7 "Catalina") _after_ this PR is applied (note the `minos 10.14`).
The result _before_ the PR on my local machine is the same except for `minos 10.15`.
The result on the released binary is:
```
/Volumes/webcamoid-portable-9.0.0/Webcamoid.app/Contents/MacOS/Webcamoid:
Load command 10
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 11.6
      sdk 12.1
   ntools 1
     tool LD
  version 711.0
Load command 11
      cmd LC_SOURCE_VERSION
  cmdsize 16
  version 0.0
```
i.e. only supports macOS 11.6 or newer.

Since this is a change of the CI script, prior to merging it should be checked (with `vtool`), that the binary produced by the CI run triggered by this PR actually has `minos 10.14`.