### PR TITLE
Fix qtaudio build breaking on desktop Linux

### DIFF
--- a/libAvKys/Plugins/AudioDevice/src/qtaudio/src/audiodevqt.cpp
+++ b/libAvKys/Plugins/AudioDevice/src/qtaudio/src/audiodevqt.cpp
@@ -84,7 +84,7 @@ class AudioDevQtPrivate
         bool m_isCapture {false};
         bool m_hasAudioCapturePermissions {false};
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if (defined(Q_OS_ANDROID) || defined(Q_OS_MACOS)) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
         QMicrophonePermission m_microphonePermission;
         bool m_permissionResultReady {false};
 #endif


### PR DESCRIPTION
Match line 87's if-guard to be the same as the others at lines 34 and 114. Summary is more detailed.

# README

Before contributing, please read [the contributing document](https://github.com/webcamoid/webcamoid/blob/master/CONTRIBUTING.md), and the [coding style and conventions](https://github.com/webcamoid/webcamoid/wiki/Coding-style-and-conventions) guide.
Search the [pull request list](https://github.com/webcamoid/webcamoid/pulls) for similar pulls before opening a new one.
Check your code doesn't throw any warning or error message while compiling, and doesn't give any warning in Clang static analyzer. Make sure your code is GCC, Clang, MinGW and MSVC compliant (use Github Actions for that).
Check your code using GDB, Valgrind and similar tools to remove all possible memory leaks and segfaults.

# Pull request

## Type of change

Is your pull request a bug fix, new feature, code refactor, breaking change, etc.?
If your change is too big consider [discussing it](https://github.com/webcamoid/webcamoid/issues) before pulling.

This change is a very minor bug fix.

## Summary

Describe your pull request the best as you can.

The QPermissions header is only pulled in on Android and MacOS with Qt >= 6.5.0. If I'm on a desktop Linux distro with Qt >= 6.5.0 (or Windows/*BSD), the QPermissions header isn't pulled in on line 34 but the buggy behavior was that it still tried to use QMicrophonePermission on line 88, which isn't possible without QPermissions. Since QPermissions can't be built on Linux as of 6.5 because it's only implemented for Apple, Android, and WASM targets, simply restrict usage of QMicrophonePermission to Apple & Android rather than attempt to expand QPermissions to work on other OSes.

## Related Issue

Is this pull request related to some [issue](https://github.com/webcamoid/webcamoid/issues)? Cite the issue as #NNN, where NNN is the number of issue.

No.

## More info

Provide screenshots, logs, etc. if required.

## Added dependencies

Does your pull request add more dependencies to the project? This may require some discussion. Minimal dependencies is a requirement.

No.

## Target Environment

Is this pull request specific to a target operating system?

* Operating System information: Linux, Qt >= 6.5
* Operating System information: Windows, Qt >= 6.5
* Operating System information: *BSD, Qt >= 6.5